### PR TITLE
Prevent the 'no handlers' message from logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 dist
 build
+*.egg-info/
+*.egg

--- a/src/recurrent/__init__.py
+++ b/src/recurrent/__init__.py
@@ -1,3 +1,12 @@
+import logging
+
+log = logging.getLogger(__name__)
+try:
+    # Prevent output if no handler set
+    log.addHandler(logging.NullHandler())
+except AttributeError:
+    pass
+
 from event_parser import RecurringEvent
 
 def parse(s, now=None):


### PR DESCRIPTION
When using recurrent with Python 2.7, the logging module will print the message `'No handlers could be found for logger "recurrent"'`. This occurs when not handlers have been set up in the logging module, which is the case when importing recurrent in an interpreter, for example.

This commit adds a `NullHandler`, which does nothing when other handlers exist, and suppresses the message if no other handlers exist. Since `NullHandler` was added in Python 2.7, we do this in a try/except so that it doesn't fail in Python 2.6.

---

Also as a sidenote, I'm finding this library quite useful in a few projects of mine and I'd be happy to update the infrastructure in this repo to match modern conventions (e.g., using pytest for testing). Would you be interested in those kinds of pull requests?
