### PR TITLE
python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.2.4'
+version = '0.2.5'
 
 setup(name='recurrent',
       version=version,

--- a/src/recurrent/__init__.py
+++ b/src/recurrent/__init__.py
@@ -1,4 +1,4 @@
-from event_parser import RecurringEvent
+from recurrent.event_parser import RecurringEvent
 
 def parse(s, now=None):
     return RecurringEvent(now).parse(s)

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -9,7 +9,7 @@ except ImportError:
 
 pdt = parsedatetime.Calendar()
 
-from constants import *
+from recurrent.constants import *
 
 log = logging.getLogger('recurrent')
 #log.setLevel(logging.DEBUG)
@@ -178,7 +178,7 @@ class RecurringEvent(object):
             rrule += 'DTSTART:%s\n' % params.pop('dtstart')
         rrule += "RRULE:"
         rules = []
-        for k, v in params.items():
+        for k, v in list(params.items()):
             if isinstance(v, str) or isinstance(v, int):
                 if isinstance(v, str):
                     v = v.upper()
@@ -281,7 +281,7 @@ class RecurringEvent(object):
 
     def parse_event(self, s):
         tokens = Tokenizer(s)
-        tokens = [t for t in tokens if t.type_ in map(lambda x: x[0], Tokenizer.CONTENT_TYPES) ]
+        tokens = [t for t in tokens if t.type_ in [x[0] for x in Tokenizer.CONTENT_TYPES] ]
         if not tokens:
             return False
         types = set([t.type_ for t in tokens])

--- a/src/recurrent/test.py
+++ b/src/recurrent/test.py
@@ -2,7 +2,7 @@ import unittest
 import datetime
 from dateutil import rrule
 
-from event_parser import RecurringEvent
+from recurrent.event_parser import RecurringEvent
 
 NOW = datetime.datetime(2010, 1, 1)
 
@@ -180,7 +180,7 @@ def test_expression(string, expected):
             expected_params = expected.correct_value
         try:
             if expected_params is None:
-                self.assertTrue(val is None or date.get_params().keys() == ['interval'],
+                self.assertTrue(val is None or list(date.get_params().keys()) == ['interval'],
                             "Non-date error: '%s' -> '%s', expected '%s'"%(
                                 string, val, expected_params))
             elif isinstance(expected_params, datetime.datetime) or isinstance(expected_params, datetime.date):
@@ -194,19 +194,19 @@ def test_expression(string, expected):
                                 string, val, expected_params))
             else:
                 actual_params = date.get_params()
-                for k, v in expected_params.items():
+                for k, v in list(expected_params.items()):
                     av = actual_params.pop(k, None)
                     self.assertEqual(av, v,
                             "Rule mismatch on rule '%s' for '%s'. Expected %s, got %s\nRules: %s" % (k, string, v, av,
                                 date.get_params()))
                 # make sure any extra params are empty/false
-                for k, v in actual_params.items():
+                for k, v in list(actual_params.items()):
                     self.assertFalse(v)
                 # ensure rrule string can be parsed by dateutil
                 rrule.rrulestr(val)
-        except AssertionError, e:
+        except AssertionError as e:
             if known_failure:
-                print "Expected failure:", expected_params
+                print("Expected failure:", expected_params)
                 return
             raise e
         if known_failure:
@@ -220,5 +220,5 @@ for i, expr in enumerate(expressions):
 
 
 if __name__ == '__main__':
-    print "Dates relative to %s" % NOW
+    print("Dates relative to %s" % NOW)
     unittest.main(verbosity=2)


### PR DESCRIPTION
Basically ran 2to3, fixed up imports. It appears to work, almost all tests pass except two that I assume fail due to the aforementioned `parsedatetime` bug. Bumped version#.
