### PR TITLE
Feat: Timezone awareness + Fix: 12 hour -> 24 hour conversion + Fix: Interval number selection

### DIFF
--- a/src/recurrent/constants.py
+++ b/src/recurrent/constants.py
@@ -78,12 +78,6 @@ RE_DAILY = re.compile(r'daily|everyday')
 RE_RECURRING_UNIT = re.compile(r'weekly|monthly|yearly')
 
 # getters
-def get_number(s):
-    try:
-        return int(s)
-    except ValueError:
-        return numbers.index(s)
-
 def get_ordinal_index(s):
     try:
         return int(s[:-2])
@@ -111,4 +105,3 @@ def get_unit_freq(s):
         if unit in s:
             return units_freq[i]
     raise ValueError
-

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -318,19 +318,12 @@ class RecurringEvent(object):
 
             index = 0
             while index < len(tokens):
-                if tokens[index].type_ == 'number':
-                    # we assume a bare number always specifies the interval
-                    n = get_number(tokens[index].text)
-                    if n is not None:
-                        self.interval = n
-                elif tokens[index].type_ == 'unit':
+                if tokens[index].type_ == 'unit':
                     # we assume a bare unit (grow up...) always specifies the frequency
                     self.freq = get_unit_freq(tokens[index].text)
                 elif tokens[index].type_ == 'ordinal':
                     ords = [get_ordinal_index(tokens[index].text)]
-
-                    # grab all iterated ordinals (e.g. 1st, 3rd and 4th of
-                    # november)
+                    # grab all iterated ordinals (e.g. 1st, 3rd and 4th of november)
                     while index + 1 < len(tokens) and tokens[index + 1].type_ == 'ordinal':
                         ords.append(get_ordinal_index(tokens[index + 1].text))
                         index += 1

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import logging
 from parsedatetime import Calendar
 from os import environ
+from time import tzset
 
 from recurrent.constants import *
 
@@ -111,8 +112,9 @@ class Tokenizer(list):
 
 
 class RecurringEvent(object):
-    def __init__(self, now_date=datetime.now()):
-        self.now_date = now_date
+    def __init__(self, now_date=None):
+        if now_date == None:
+            self.now_date = datetime.now()
         self._reset()
 
     def _reset(self):
@@ -183,6 +185,7 @@ class RecurringEvent(object):
         # if it is a non-recurring date, and none if it is neither.
         self._reset()
         environ['TZ'] = zone # set timezone
+        tzset()
         if not s:
             return False
         event = self.parse_start_and_end(s)

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -113,8 +113,8 @@ class Tokenizer(list):
 
 class RecurringEvent(object):
     def __init__(self, now_date=None):
-        if now_date == None:
-            self.now_date = datetime.now()
+        if now_date == None: self.now_date = datetime.now()
+        else: self.now_date = now_date
         self._reset()
 
     def _reset(self):

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -296,7 +296,7 @@ class RecurringEvent(object):
                 # a plural weekday can really only mean one
                 # of two things, weekly or biweekly
                 self.freq = 'weekly'
-                if 'bi' in s or 'every other' in s:
+                if 'bi' in s or 'every other' in s or 'every alternate' in s:
                     self.interval = 2
                 else:
                     self.interval = 1
@@ -308,7 +308,7 @@ class RecurringEvent(object):
 
         # recurring phrases
         if 'every' in types or 'recurring_unit' in types:
-            if 'every other' in s:
+            if 'every other' in s or 'every alternate' in s:
                 self.interval = 2
             else:
                 self.interval = 1


### PR DESCRIPTION
Changes:
1. Added timezone awareness in the RecurringEvent.parse method. However this works only in cases when the event is not recurring.
2. Fixed 12 hour format conversion to 24 hour format in RecurringEvent.get_hour method which earlier failed for cases like 12:xx pm
3. Fixed interval value extraction which failed for cases like "at 10 am on 15th of every month". It assumed 10 to be the event interval and extracted datetimes which were 10 months apart. Now the interval value is decided based on the frequency of the event (default values).
4. Minor modifications


For verification of the above changes try -
```
from datetime import datetime
from event_parser import RecurringEvent
from dateutil import rrule

r = RecurringEvent()
zone = 'US/Pacific'
datetime_string = 'at 10 am every day starting next Tuesday until September'
r.parse(datetime_string, zone)
rr = rrule.rrulestr(r.get_RFC_rrule())
unix_time = rr.after(datetime.now()).timestamp()
print(unix_time)

zone = 'Europe/London'
r.parse(datetime_string, zone)
rr = rrule.rrulestr(r.get_RFC_rrule())
unix_time = rr.after(datetime.now()).timestamp()
print(unix_time)

hour = r.get_hour('12', 'am')
print(hour)
hour = r.get_hour('12', 'pm')
print(hour)
hour = r.get_hour('1', 'pm')
print(hour)
hour = r.get_hour('1', 'am')
print(hour)
```

Use - 
```
from pytz import timezone, utc

def make_timezone_aware(utctime, zone):
    utctime = utctime.replace(tzinfo=utc)
    return utctime.astimezone(timezone(zone))
```

for getting timezone aware datetimes after using rrule.after() to extract next remind time for recurring events.