### PR TITLE
Allow International Formatting of parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ datetime.datetime(2010, 1, 5, 0, 0)
 datetime.datetime(2010, 1, 26, 0, 0)
 ```
 
+You can specify a (custom) localisation to change the parsing behaviour of `parsedatetime`
+```python
+consts = parsedatetime.Constants(localeID='en_US', usePyICU=False)
+consts.use24 = True
+
+r = RecurringEvent(now_date=datetime.datetime(2010, 1, 1), parse_constants=consts)
+```
+
 ## Dependencies
 Recurrent uses [parsedatetime][3] to parse dates and [python.dateutil][2] if available to optimize some results.
 

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -64,7 +64,7 @@ def normalize(s):
     s = re.sub(RE_LONG_DATE_START, r'\1 \2', s) # Remove commas in long format dates, e.g. "Tuesday, January..."
     s = re.sub(r',\s*and', ' and', s)       # Remove commas before 'and'
     s = re.sub(r',', ' and ', s)            # Change all other commas to ' and '
-    s = re.sub(r'[^\w\s/:-]', '', s)
+    s = re.sub(r'[^\w\s\./:-]', '', s)      # Allow . for international formatting
     s = re.sub(r'\s+', ' ', s)
     return s
 

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -10,8 +10,6 @@ try:
 except ImportError:     # pragma nocover
     import parsedatetime
 
-pdt = parsedatetime.Calendar()
-
 from recurrent.constants import *
 
 DEBUG=False
@@ -140,13 +138,14 @@ class Tokenizer(list):
         log.debug("tokenized '%s'\n%s" %(self.text, self))
 
 class RecurringEvent(object):
-    def __init__(self, now_date=None, preferred_time_range=(8, 19)):
+    def __init__(self, now_date=None, preferred_time_range=(8, 19), parse_constants: parsedatetime.Constants=None):
         if now_date is None:
             now_date = datetime.datetime.now()
         if isinstance(now_date, datetime.date) and not isinstance(now_date, datetime.datetime):
             now_date = datetime.datetime(now_date.year, now_date.month, now_date.day)
         self.now_date = now_date
         self.preferred_time_range = preferred_time_range
+        self.pdt = parsedatetime.Calendar(constants=parse_constants)
         self._reset()
 
     def _reset(self):
@@ -500,7 +499,7 @@ class RecurringEvent(object):
         if result:
             log.debug(f"parsed date string '{date_string}' to {result}")
             return result
-        timestruct, result = pdt.parse(date_string, self.now_date)
+        timestruct, result = self.pdt.parse(date_string, self.now_date)
         if result:
             log.debug( "parsed date string '%s' to %s" %(date_string,
                     timestruct[:6]))

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -147,6 +147,11 @@ class RecurringEvent(object):
         self.preferred_time_range = preferred_time_range
         self.pdt = parsedatetime.Calendar(constants=parse_constants)
         self._reset()
+        
+        if parse_constants and parse_constants.use24:
+            # the 24hr clock will always have this preferred time
+            # will not break pm specification
+            preferred_time_range = (0,12)
 
     def _reset(self):
         # rrule params

--- a/src/recurrent/event_parser.py
+++ b/src/recurrent/event_parser.py
@@ -827,8 +827,10 @@ class RecurringEvent(object):
                 return 0
             return hr
         if hr > 12: return hr
+        if hr == 0: return 0 # ignore preferred_time_range when 0, 0 is never 12:00
         if hr < self.preferred_time_range[0]:
             return hr + 12
+
         return hr
 
 


### PR DESCRIPTION
I was integrating this package into a project but required localisation for the parsing behaviour.
Mainly day-first parsing (e.g. 01/08/21 -> 1st August)

* I added an option to pass the `parsedatetime.Constants` object of `parsedatetime` into the constructor of the `RecurringEvent` class.
* In addition I needed to make the `pdt=parsedatetime.Calendar(constants=parse_constants)` a member variable.
* I allowed `.` to be kept when normalizing the input string, to allow international date formatting (e.g. 01.08.21)

I thought this might be usefull for the public package, the tests are all passed.
Someone with more insight on the structure of this package should perhaps make sure, that this commit doesn't influence some corner cases.